### PR TITLE
Python wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 build/
+*.gch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 project(phonetic)
 
 # Set C++ standard
@@ -50,3 +50,26 @@ else()
     # Test directory
     add_subdirectory(tests)
 endif()
+
+if (CMAKE_VERSION VERSION_LESS 3.18)
+    set(DEV_MODULE Development)
+else()
+    set(DEV_MODULE Development.Module)
+endif()
+find_package(Python 3.12 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+set_target_properties(phonetic PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+nanobind_add_module(phoneticpy src/phoneticpy.cpp)
+target_include_directories(phoneticpy PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(phoneticpy PRIVATE phonetic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,25 +51,29 @@ else()
     add_subdirectory(tests)
 endif()
 
-if (CMAKE_VERSION VERSION_LESS 3.18)
-    set(DEV_MODULE Development)
-else()
-    set(DEV_MODULE Development.Module)
+if (SKBUILD)
+    if (CMAKE_VERSION VERSION_LESS 3.18)
+        set(DEV_MODULE Development)
+    else()
+        set(DEV_MODULE Development.Module)
+    endif()
+    find_package(Python 3.12 REQUIRED COMPONENTS Interpreter ${DEV_MODULE} OPTIONAL_COMPONENTS Development.SABIModule)
+
+    if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+        set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    endif()
+
+    set_target_properties(phonetic PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+    execute_process(
+        COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+    find_package(nanobind CONFIG REQUIRED)
+
+    nanobind_add_module(phoneticpy STABLE_ABI src/phoneticpy.cpp)
+    target_include_directories(phoneticpy PUBLIC ${CMAKE_SOURCE_DIR}/include)
+    target_link_libraries(phoneticpy PRIVATE phonetic)
+
+    install(TARGETS phoneticpy LIBRARY DESTINATION phoneticpy)
 endif()
-find_package(Python 3.12 COMPONENTS Interpreter ${DEV_MODULE} REQUIRED)
-
-if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-endif()
-
-set_target_properties(phonetic PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-execute_process(
-    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
-    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
-find_package(nanobind CONFIG REQUIRED)
-
-nanobind_add_module(phoneticpy src/phoneticpy.cpp)
-target_include_directories(phoneticpy PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(phoneticpy PRIVATE phonetic)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "phoneticpy"
+version = "0.0.1"
+description = "Python bindings to a C++ interface to the CMU pronouncing dictionary"
+readme = "readme.md"
+requires-python = ">=3.12"
+authors = [
+    { name = "Nate Woods" },
+    { name = "Peter Chinman" }
+]
+# Optional: runtime dependency specification
+# dependencies = [ "cryptography >=41.0" ]
+
+[project.urls]
+Homepage = "https://github.com/peterchinman/phonetic"
+
+[tool.scikit-build]
+# Protect the configuration against future changes in scikit-build-core
+minimum-version = "0.4"
+
+# Setuptools-style build caching in a local directory
+build-dir = "build/{wheel_tag}"
+
+# Build stable ABI wheels for CPython 3.12+
+wheel.py-api = "cp312"

--- a/src/phoneticpy.cpp
+++ b/src/phoneticpy.cpp
@@ -2,8 +2,6 @@
 #include<nanobind/stl/string.h>
 #include<nanobind/stl/vector.h>
 #include<nanobind/stl/pair.h>
-#include<nanobind/stl/vector.h>
-#include<nanobind/stl/vector.h>
 
 #include "phonetic.hpp"
 

--- a/src/phoneticpy.cpp
+++ b/src/phoneticpy.cpp
@@ -1,0 +1,24 @@
+#include<nanobind/nanobind.h>
+#include<nanobind/stl/string.h>
+#include<nanobind/stl/vector.h>
+#include<nanobind/stl/pair.h>
+#include<nanobind/stl/vector.h>
+#include<nanobind/stl/vector.h>
+
+#include "phonetic.hpp"
+
+namespace nb = nanobind;
+
+NB_MODULE(phoneticpy, m)
+{
+    nb::class_<Phonetic>(m, "Phonetic")
+        .def(nb::init<>())
+        .def("import_dictionary", &Phonetic::import_dictionary)
+        .def("word_to_phones", &Phonetic::word_to_phones)
+        .def("text_to_phones", &Phonetic::text_to_phones)
+        .def("phone_to_stress", &Phonetic::phone_to_stress)
+        .def("word_to_stresses", &Phonetic::word_to_stresses)
+        .def("phone_to_syllable_count", &Phonetic::phone_to_syllable_count)
+        .def("word_to_syllable_counts", &Phonetic::word_to_syllable_counts)
+        .def("get_rhyming_part", &Phonetic::get_rhyming_part);
+}

--- a/src/phoneticpy/__init__.py
+++ b/src/phoneticpy/__init__.py
@@ -1,0 +1,1 @@
+from .phoneticpy import Phonetic


### PR DESCRIPTION
This still needs some tweaking, mostly (entirely?) on the cmake side since I don't really know cmake. In particular, it probably shouldn't generate wrappers by default (nanobind shouldn't be a dependency unless you actually want python) and there's probably some nice way to make it easy to add the wrappers to your python path in a virtualenv or similar.